### PR TITLE
Fix error output

### DIFF
--- a/lib/Data/SafeCopy/Migrate.hs
+++ b/lib/Data/SafeCopy/Migrate.hs
@@ -221,8 +221,8 @@ changelog bareTyName (newVer, Past oldVer) changes = do
              (show (mkNew n)) (show newTyName)
   for_ (M.keys removed) $ \n ->
     when (n `elem` map fst fields) $ fail $
-      printf "changelog: field %s is present in %s \
-             \but was supposed to be removed"
+      printf "changelog: field %s is present in %s\
+             \ but was supposed to be removed"
              (show (mkNew n)) (show newTyName)
 
   -- -----------------------------------------------------------------------


### PR DESCRIPTION
Because of `\b` the output is
```
changelog: field _someField is present in SomeType              ut was supposed to be removed
```
instead of 
```
changelog: field _someField is present in SomeType but was supposed to be removed
```